### PR TITLE
chore: drop `*` wildcard from CODEOWNERS to stop Dependabot review pings

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,6 @@
 # CODEOWNERS - Require review for all changes.
 
 # Default: require maintainer review for everything
-* @hyperpolymath
 
 # Security-critical paths — reviewer must read SECURITY.adoc before approving.
 /vault-broker/src/    @hyperpolymath

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,8 +14,6 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
-    reviewers:
-      - "hyperpolymath"
     labels: ["dependencies", "security", "rust"]
     commit-message:
       prefix: "chore(deps)"
@@ -29,8 +27,6 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
-    reviewers:
-      - "hyperpolymath"
     labels: ["dependencies", "security", "rust", "wasm"]
     commit-message:
       prefix: "chore(deps)"
@@ -42,8 +38,6 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
-    reviewers:
-      - "hyperpolymath"
     labels: ["dependencies", "security", "rust"]
     commit-message:
       prefix: "chore(deps)"
@@ -56,8 +50,6 @@ updates:
       interval: "daily"
       time: "06:00"
     open-pull-requests-limit: 10
-    reviewers:
-      - "hyperpolymath"
     labels:
       - "dependencies"
       - "ci"
@@ -70,8 +62,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    reviewers:
-      - "hyperpolymath"
     labels:
       - "dependencies"
       - "nix"


### PR DESCRIPTION
The catch-all `* @hyperpolymath` line in CODEOWNERS causes GitHub to auto-request review on every Dependabot PR (since every PR touches at least one owned path under `*`). With the sole maintainer being the same user, those review requests are pure notification noise.

This drops the wildcard line while preserving any path-specific ownership and SPDX/license headers. Path-specific lines are intentional and stay.

Human PRs from collaborators still trigger path-owner review where applicable; Dependabot PRs typically only touch root manifest files which are no longer matched.