### PR TITLE
chore(ci): retarget hypatia-scan wrapper to standards#193 HEAD

### DIFF
--- a/.github/workflows/hypatia-scan.yml
+++ b/.github/workflows/hypatia-scan.yml
@@ -25,5 +25,5 @@ permissions:
 
 jobs:
   hypatia:
-    uses: hyperpolymath/standards/.github/workflows/hypatia-scan-reusable.yml@2569c10e831e293f9dd6580d82a494aca039deee
+    uses: hyperpolymath/standards/.github/workflows/hypatia-scan-reusable.yml@97df762107501909f50bb770e9bc200b6c415600
     secrets: inherit


### PR DESCRIPTION
## Summary

The hypatia-scan wrapper in this repo was merged pinned to standards#191 HEAD `2569c10e831e293f9dd6580d82a494aca039deee`. Standards#191 was subsequently closed in favour of standards#193 (parallel-session implementation with a strictly simpler API — zero inputs except `runs-on`).

The pinned commit remains git-reachable via `refs/pull/191/head` so the workflow keeps functioning, but it doesn't track the canonical #193 implementation that's headed for main.

This PR repins the wrapper at #193 HEAD `97df762107501909f50bb770e9bc200b6c415600` so it picks up the merged reusable once #193 lands.

## Test plan

- [ ] After standards#193 merges, the next push uses the merged reusable
- [ ] Behaviour unchanged before then (still pinned to a reachable commit)

Refs standards#193.

🤖 Generated with [Claude Code](https://claude.com/claude-code)