### PR TITLE
ci(scorecard): add job-level permissions for reusable workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -12,5 +12,8 @@ permissions: read-all
 
 jobs:
   analysis:
+    permissions:
+      security-events: write
+      id-token: write
     uses: hyperpolymath/standards/.github/workflows/scorecard-reusable.yml@e0caf11508a3989574713c78f5f444f2ce5e33ef
     secrets: inherit


### PR DESCRIPTION
## Summary
- Add `permissions: { security-events: write, id-token: write }` to `jobs.analysis` so the called scorecard reusable can upload SARIF.
- Without job-level overrides the caller's `permissions: read-all` caps the reusable and `ossf/scorecard-action` silently `startup_failure`s.

Refs hyperpolymath/standards#282

## Test plan
- [x] Local diff is 3 lines exactly
- [ ] CI green
- [ ] Auto-merge squash + delete-branch on green

🤖 Generated with [Claude Code](https://claude.com/claude-code)