### PR TITLE
chore(clade): backfill [status] lifecycle block

### DIFF
--- a/.machine_readable/CLADE.a2ml
+++ b/.machine_readable/CLADE.a2ml
@@ -32,3 +32,24 @@ name = "CLADE"
 type = "standalone"
 parent = "Token/secret management vault"
 born = "2026-03-16"
+
+# Lifecycle status (added by clade-status-backfill; see gv-clade-index ADR 0006).
+# Identity (uuid) and status are SEPARATE layers: uuid is immortal; phase is a
+# mutable pointer. No phase is terminal (extinct -> active is a legal "Gitassic
+# Park" transition on the same uuid). A rename is NOT a phase change — the old
+# prefixed-name goes to aliases[], uuid and phase are untouched.
+[status]
+# One of: reserved incubating active dormant | merged superseded archived extinct
+phase = "active"
+since = "2026-03-16"
+present = true
+aliases = []
+merged-into = ""
+superseded-by = ""
+successors = []
+ended = ""
+
+[[status.history]]
+phase = "active"
+since = "2026-03-16"
+note = "backfilled default — correct if the true phase differs"


### PR DESCRIPTION
Backfills the `[status]` lifecycle block (default `active`, `since=2026-03-16`) required by clade-hygiene CLADE-004/005 — see gv-clade-index ADR 0006. Correct the phase if it isn't actually active.